### PR TITLE
Support Windows terminal.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "glyph"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-termion = "1.5"
+crossterm = "0.23"
 bytes = "*"
 
 [[example]]


### PR DESCRIPTION
With this patch, we move to `crossterm` instead of `termion`. At the very least, the code now compiles on Windows. Needs to be tested on some Windows terminals before merging.